### PR TITLE
Allowing client to optionally specify state key

### DIFF
--- a/client/bb-client.js
+++ b/client/bb-client.js
@@ -308,7 +308,7 @@ BBClient.authorize = function(params, errback){
 
     params.provider = provider;
 
-    var state = Guid.newGuid();
+    var state = params.client.state || Guid.newGuid();
     var client = params.client;
 
     if (params.provider.oauth2 == null) {


### PR DESCRIPTION
Quick tweak to the OAuth2 authorize method to allow the client to specify the state key instead of always generating a new GUID.
