### PR TITLE
Fixed typo in Search parameter creation

### DIFF
--- a/client/search-specification.js
+++ b/client/search-specification.js
@@ -241,7 +241,7 @@ module.exports = function(mixins) {
   function NumberSearchParam(name){
     SearchParam.apply(this, arguments);
   }
-  NumberSearchParam();
+  NumberSearchParam.prototype = new SearchParam();
   NumberSearchParam.prototype.constructor = NumberSearchParam;
 
   function QuantitySearchParam(name){


### PR DESCRIPTION
It seems there was an error in the duplication of the construction of each search parameter type for the Number search parameter type. This could cause runtime errors, as `this` would be undefined—of course, properties cannot be set on `undefined`.