### PR TITLE
Removed the jQuery dependency from bb-client.

### DIFF
--- a/src/client/bb-client.js
+++ b/src/client/bb-client.js
@@ -170,7 +170,7 @@ function completeTokenRefreshFlow() {
       refresh_token: refresh_token
     },
   }).then(function(authz) {
-    authz = $.extend(tokenResponse, authz);
+    authz = FhirClient.extend(tokenResponse, authz);
     ret.resolve(authz);
   }, function() {
     console.warn('Failed to exchange refresh_token for access_token', arguments);
@@ -325,7 +325,7 @@ BBClient.ready = function(input, callback, errback){
       sessionStorage.tokenResponse = JSON.stringify(tokenResponse);
     } else {
       //Save the tokenResponse object and the state into sessionStorage keyed by state
-      var combinedObject = $.extend(true, JSON.parse(sessionStorage[tokenResponse.state]), { 'tokenResponse' : tokenResponse });
+      var combinedObject = FhirClient.extend(true, JSON.parse(sessionStorage[tokenResponse.state]), { 'tokenResponse' : tokenResponse });
       sessionStorage[tokenResponse.state] = JSON.stringify(combinedObject);
     }
 
@@ -511,7 +511,7 @@ BBClient.authorize = function(params, errback){
         sessionStorage[state] = JSON.stringify(params);
         sessionStorage.tokenResponse = JSON.stringify({state: state});
       } else {
-        var combinedObject = $.extend(true, params, { 'tokenResponse' : {state: state} });
+        var combinedObject = FhirClient.extend(true, params, { 'tokenResponse' : {state: state} });
         sessionStorage[state] = JSON.stringify(combinedObject);
       }
 

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -1,5 +1,89 @@
 var utils = module.exports =  {};
 
+// https://github.com/jquery/jquery/issues/3444
+utils.extend = function() {
+  var source, name, sourceProperty, targetProperty, clonedTargetProperty,
+    target = arguments[ 0 ],
+    i = 1,
+    length = arguments.length,
+    deep = false
+
+  // Handle a deep copy situation
+  if ( typeof target == "boolean" ) {
+    deep = target
+
+    // Skip the boolean and the target
+    target = arguments[ i ]
+    i++
+  }
+
+  // Extend jQuery itself if only one argument is passed
+  if ( i == length ) {
+    target = this
+    i--
+  }
+
+  // Loop through n objects
+  for ( ; i < length; i++ ) {
+    source = arguments[ i ]
+
+    // Only deal with non-null/undefined values
+    // NOTE: How was the previous source != null getting away with loose comparison?
+    // In any event, it is obfuscating to do loose comparison to null
+    if ( source !== null && source !== undefined ) {
+
+      // Extend the base object
+      for ( name in source ) {
+        targetProperty = target[ name ]
+        sourceProperty = source[ name ]
+
+        // Prevent infinite loop
+        if ( target !== sourceProperty ) {
+          if ( deep && sourceProperty ) {
+            clonedTargetProperty = null
+
+            if ( Array.isArray( sourceProperty ) ) {
+              clonedTargetProperty = targetProperty &&
+                Array.isArray( targetProperty )
+                ? targetProperty : []
+            } else if ( isPlainObject( sourceProperty ) ) {
+              clonedTargetProperty = targetProperty &&
+                isPlainObject( targetProperty )
+                ? targetProperty : {}
+            }
+
+            target[ name ] = clonedTargetProperty
+              ? extend( true, clonedTargetProperty, sourceProperty )
+              : sourceProperty
+
+          // Don't bring in undefined values
+          } else if ( sourceProperty !== undefined ) {
+            target[ name ] = sourceProperty
+          }
+        }
+      }
+    }
+  }
+
+  // Return the modified object
+  return target
+}
+
+function getProto() { return Object.getPrototypeOf }
+
+function isPlainObject (obj) {
+  var proto
+
+    if ( toString.call( obj ) == "[object Object]" ) {
+      proto = getProto( obj )
+
+      // Objects foolish enough to have prototypes with their own - hasOwnProperty - method are not supported
+      return !proto || !proto.hasOwnProperty || proto.hasOwnProperty( "hasOwnProperty" )
+    }
+
+    return false
+}
+
 utils.byCodes = function(observations, property){
 
   var bank = utils.byCode(observations, property);


### PR DESCRIPTION
Summary of changes:
 - Added an extend method to `utils.js` that is taken from https://github.com/jquery/jquery/issues/3444
 - Updated `bb-client.js` so that it doesn't have a needless dependency on jQuery
 - This is so that those who use ReactJS can keep from having to pull in jQuery or polyfill the $.extend method.
 - tested the change with a SMART on FHIR app we are developing in the Cerner Sandbox Environment