### PR TITLE
Fixes a nasty Firefox issue, implements patient context aware request wrapper, adds create/update/delete convenince wrappers, fixes fake token response workflow

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -129,13 +129,13 @@ client.request(
 ```
 
 ### client.create(resource: Object) `Promise<Object>`
-A wrapper for `client.request` implementing the FHIR resource create operation.
+Wrapper for `client.request` implementing the FHIR resource create operation.
 
 ### client.update(resource: Object) `Promise<Object>`
-A wrapper for `client.request` implementing the FHIR resource update operation.
+Wrapper for `client.request` implementing the FHIR resource update operation.
 
-### client.delete(url: String) `Promise<Object>`
-A wrapper for `client.request` implementing the FHIR resource delete operation.
+### client.delete(uri: String) `Promise<Object>`
+Wrapper for `client.request` implementing the FHIR resource delete operation.
 
 ***Example:***
 ```js

--- a/docs/client.md
+++ b/docs/client.md
@@ -128,6 +128,20 @@ client.request(
 );
 ```
 
+### client.create(resource: Object) `Promise<Object>`
+A wrapper for `client.request` implementing the FHIR resource create operation.
+
+### client.update(resource: Object) `Promise<Object>`
+A wrapper for `client.request` implementing the FHIR resource update operation.
+
+### client.delete(url: String) `Promise<Object>`
+A wrapper for `client.request` implementing the FHIR resource delete operation.
+
+***Example:***
+```js
+client.delete("Patient/id");
+```
+
 ### client.refresh() `Promise<Object>`
 Use the refresh token to obtain new access token. If the refresh token is
 expired (or this fails for any other reason) it will be deleted from the

--- a/docs/fhirjs-equivalents.md
+++ b/docs/fhirjs-equivalents.md
@@ -33,6 +33,10 @@ client.request({
     body: data
 })
 ```
+or
+```js
+client.create(data)
+```
 
 ### update
 ```js
@@ -42,6 +46,10 @@ client.request({
     body: data
 })
 ```
+or
+```js
+client.update(data)
+```
 
 ### delete
 ```js
@@ -49,6 +57,10 @@ client.request({
     url: "ResourceType/resourceId",
     method: "DELETE"
 })
+```
+or
+```js
+client.delete("ResourceType/resourceId")
 ```
 
 ### patch

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -141,7 +141,7 @@ The v2 client includes convenience wrappers for FHIR create, update, delete oper
 
 For example:
 ```js
-client.patient.api.update({resource: resource})
+client.api.update({resource: resource})
 ```
 can be changed to:
 ```js

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -97,7 +97,7 @@ must be changed to:
 patient.read().then(...).catch(...).finally(...)
 ```
 
-#### Other requests
+#### Other read requests
 Other requests should be convertible to `client.request()`. We can't
 cover every possible scenario, but we can provide an example for one use case
 that seems to be very common - fetching patient observations.
@@ -135,6 +135,30 @@ FHIR.oauth2.ready()
     .catch(console.error);
 ```
 See [this](./fhirjs-equivalents) for other examples.
+
+#### Common write requests
+The v2 client includes convenience wrappers for FHIR create, update, delete operations.
+
+For example:
+```js
+client.patient.api.update({resource: resource})
+```
+can be changed to:
+```js
+client.update(resource)
+```
+
+Here are examples for create and delete:
+```js
+client.create(resource)
+```
+```js
+client.delete("Patient/123")
+```
+
+#### Other write requests
+Other write requests should be converted to `client.request()`.
+See [this](./fhirjs-equivalents) for examples.
 
 ### Other Changes
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -14,8 +14,8 @@ const {
 } = require("./lib");
 
 const debug = _debug.extend("client");
-
 const str = require("./strings");
+const contextualize = require("./patient");
 
 /**
  * Gets single reference by id. Caches the result.
@@ -158,6 +158,11 @@ class FhirClient
                 const id = this.patient.id;
                 return id ?
                     this.request(`Patient/${id}`) :
+                    Promise.reject(new Error("Patient is not available"));
+            },
+            request: (requestOptions, fhirOptions = {}, _resolvedRefs = {}) => {
+                return this.patient.id ?
+                    this.request(contextualize(requestOptions, this), fhirOptions, _resolvedRefs) :
                     Promise.reject(new Error("Patient is not available"));
             }
         };

--- a/src/Client.js
+++ b/src/Client.js
@@ -428,12 +428,12 @@ class FhirClient
     }
 
     /**
-     * @param {String} url Relative URL of the FHIR resource to be deleted (format: `resourceType/id`)
+     * @param {String} uri Relative URL of the FHIR resource to be deleted (format: `resourceType/id`)
      */
-    async delete(url)
+    async delete(uri)
     {
         return this.request({
-            url: url,
+            url: uri,
             method: "DELETE"
         });
     }

--- a/src/Client.js
+++ b/src/Client.js
@@ -398,6 +398,47 @@ class FhirClient
     }
 
     /**
+     * @param {Object} resource A FHIR resource to be created
+     */
+    async create(resource)
+    {
+        return this.request({
+            url: `${resource.resourceType}`,
+            method: "POST",
+            body: JSON.stringify(resource),
+            headers:{
+                "Content-Type": "application/fhir+json"
+            }
+        });
+    }
+
+    /**
+     * @param {Object} resource A FHIR resource to be updated
+     */
+    async update(resource)
+    {
+        return this.request({
+            url: `${resource.resourceType}/${resource.id}`,
+            method: "PUT",
+            body: JSON.stringify(resource),
+            headers:{
+                "Content-Type": "application/fhir+json"
+            }
+        });
+    }
+
+    /**
+     * @param {String} url Relative URL of the FHIR resource to be deleted (format: `resourceType/id`)
+     */
+    async delete(url)
+    {
+        return this.request({
+            url: url,
+            method: "DELETE"
+        });
+    }
+
+    /**
      * @param {Object|String} requestOptions Can be a string URL (relative to
      *  the serviceUrl), or an object which will be passed to fetch()
      * @param {fhirclient.FhirOptions} fhirOptions Additional options to control the behavior

--- a/src/Client.js
+++ b/src/Client.js
@@ -400,7 +400,7 @@ class FhirClient
     /**
      * @param {Object} resource A FHIR resource to be created
      */
-    async create(resource)
+    create(resource)
     {
         return this.request({
             url: `${resource.resourceType}`,
@@ -415,7 +415,7 @@ class FhirClient
     /**
      * @param {Object} resource A FHIR resource to be updated
      */
-    async update(resource)
+    update(resource)
     {
         return this.request({
             url: `${resource.resourceType}/${resource.id}`,
@@ -428,9 +428,9 @@ class FhirClient
     }
 
     /**
-     * @param {String} uri Relative URL of the FHIR resource to be deleted (format: `resourceType/id`)
+     * @param {String} uri Relative URI of the FHIR resource to be deleted (format: `resourceType/id`)
      */
-    async delete(uri)
+    delete(uri)
     {
         return this.request({
             url: uri,

--- a/src/adapters/BaseAdapter.js
+++ b/src/adapters/BaseAdapter.js
@@ -18,6 +18,12 @@ class BaseAdapter
             // using window.history.replaceState API or by reloading.
             replaceBrowserHistory: true,
 
+            // Enables workaround for Firefox history.replaceState bug (see https://bugzilla.mozilla.org/show_bug.cgi?id=1422334)
+            // Affected Firefox versions: 56.0+
+            // Bug still present in Firefox 68.0
+            // Side effects of workaround: `#` added to app URL. If this is not desirable set to false.
+            fixBug1422334: true,
+
             // When set to true, this variable will fully utilize
             // HTML5 sessionStorage API.
             // This variable can be overridden to false by setting

--- a/src/patient.js
+++ b/src/patient.js
@@ -1,56 +1,3 @@
-// List of resources with 'patient' or 'subject' properties (as of FHIR DSTU2 1.0.0)
-// (Based on https://github.com/FHIR/fhir.js/blob/master/src/middlewares/patient.js)
-var targets = [
-    "Account",
-    "AllergyIntolerance",
-    "BodySite",
-    "CarePlan",
-    "Claim",
-    "ClinicalImpression",
-    "Communication",
-    "CommunicationRequest",
-    "Composition",
-    "Condition",
-    "Contract",
-    "DetectedIssue",
-    "Device",
-    "DeviceUseRequest",
-    "DeviceUseStatement",
-    "DiagnosticOrder",
-    "DiagnosticReport",
-    "DocumentManifest",
-    "DocumentReference",
-    "Encounter",
-    "EnrollmentRequest",
-    "EpisodeOfCare",
-    "FamilyMemberHistory",
-    "Flag",
-    "Goal",
-    "ImagingObjectSelection",
-    "ImagingStudy",
-    "Immunization",
-    "ImmunizationRecommendation",
-    "List",
-    "Media",
-    "MedicationAdministration",
-    "MedicationDispense",
-    "MedicationOrder",
-    "MedicationStatement",
-    "NutritionOrder",
-    "Observation",
-    "Order",
-    "Procedure",
-    "ProcedureRequest",
-    "QuestionnaireResponse",
-    "ReferralRequest",
-    "RelatedPerson",
-    "RiskAssessment",
-    "Specimen",
-    "SupplyDelivery",
-    "SupplyRequest",
-    "VisionPrescription"
-];
-
 const {
     absolute,
     debug: _debug
@@ -76,9 +23,12 @@ function contextualize (requestOptions, client) {
         const type = url.pathname.split("/").pop();
         const params = url.searchParams;
 
-        if (targets.indexOf(type) >= 0){
-            params.set("patient", patient);
-        }
+        // Adding a 'patient' parameter may not be appropriate for all
+        // FHIR queries and resource types (this varies between FHIR versions).
+        // To make this as FHIR version independent as possible, we keep it simple
+        // and leave it to the apps using the client to determine if it makes sense
+        // to run a query throught this wrapper or not.
+        params.set("patient", patient);
     
         debug(`Contextualized request url: ${url.href}`);
 

--- a/src/patient.js
+++ b/src/patient.js
@@ -1,0 +1,99 @@
+// List of resources with 'patient' or 'subject' properties (as of FHIR DSTU2 1.0.0)
+// (Based on https://github.com/FHIR/fhir.js/blob/master/src/middlewares/patient.js)
+var targets = [
+    "Account",
+    "AllergyIntolerance",
+    "BodySite",
+    "CarePlan",
+    "Claim",
+    "ClinicalImpression",
+    "Communication",
+    "CommunicationRequest",
+    "Composition",
+    "Condition",
+    "Contract",
+    "DetectedIssue",
+    "Device",
+    "DeviceUseRequest",
+    "DeviceUseStatement",
+    "DiagnosticOrder",
+    "DiagnosticReport",
+    "DocumentManifest",
+    "DocumentReference",
+    "Encounter",
+    "EnrollmentRequest",
+    "EpisodeOfCare",
+    "FamilyMemberHistory",
+    "Flag",
+    "Goal",
+    "ImagingObjectSelection",
+    "ImagingStudy",
+    "Immunization",
+    "ImmunizationRecommendation",
+    "List",
+    "Media",
+    "MedicationAdministration",
+    "MedicationDispense",
+    "MedicationOrder",
+    "MedicationStatement",
+    "NutritionOrder",
+    "Observation",
+    "Order",
+    "Procedure",
+    "ProcedureRequest",
+    "QuestionnaireResponse",
+    "ReferralRequest",
+    "RelatedPerson",
+    "RiskAssessment",
+    "Specimen",
+    "SupplyDelivery",
+    "SupplyRequest",
+    "VisionPrescription"
+];
+
+const {
+    absolute,
+    debug: _debug
+} = require("./lib");
+
+const debug = _debug.extend("client:patient");
+
+/**
+ * Adds patient context to requestOptions object to be used with fhirclient.Client.request
+ * @param {Object|String} requestOptions Can be a string URL (relative to
+ *  the serviceUrl), or an object which will be passed to fetch()
+ * @param {fhirclient.Client} client Current FHIR client object containing patient context
+ * @return {Object|String} requestOptions object contextualied to current patient
+ */
+function contextualize (requestOptions, client) {
+
+    const patient = client.patient.id;
+    const base = absolute("/", client.state.serverUrl);
+
+    if (!patient) return Promise.reject(new Error("Patient is not available"));
+
+    function contextualURL(url) {
+        const type = url.pathname.split("/").pop();
+        const params = url.searchParams;
+
+        if (targets.indexOf(type) >= 0){
+            params.set("patient", patient);
+        }
+    
+        debug(`Contextualized request url: ${url.href}`);
+
+        return url.href;
+    }
+
+    if (typeof requestOptions == "string" || requestOptions instanceof URL) {
+        let url = new URL(requestOptions, base);
+        return contextualURL(url);
+    }
+    else {
+        let url = new URL(requestOptions.url, base);
+        requestOptions.url = contextualURL(url);
+        return requestOptions;
+    }
+}
+
+module.exports = contextualize;

--- a/src/smart.js
+++ b/src/smart.js
@@ -300,6 +300,7 @@ async function completeAuth(env)
         // Side effects of workaround: `#` added to app URL. If this is not desirable set `fixBug1422334` to false.
         if (getPath(env, "options.fixBug1422334")) {
             location.hash = location.hash;
+            debug("Applied workaround for Firefox bug 1422334.");
         }
 
         // If the browser does not support the replaceState method for the
@@ -310,6 +311,7 @@ async function completeAuth(env)
         // should be set to false.
         if (window.history.replaceState) {
             window.history.replaceState({}, "", url.href);
+            debug("Url updated to: " + url.href);
         }
     }
 

--- a/src/smart.js
+++ b/src/smart.js
@@ -294,6 +294,14 @@ async function completeAuth(env)
             debug("Removed state parameter from the url.");
         }
 
+        // Workaround for Firefox history.replaceState bug (see https://bugzilla.mozilla.org/show_bug.cgi?id=1422334)
+        // Affected Firefox versions: 56.0+
+        // Bug still present in Firefox 68.0
+        // Side effects of workaround: `#` added to app URL. If this is not desirable set `fixBug1422334` to false.
+        if (getPath(env, "options.fixBug1422334")) {
+            location.hash = location.hash;
+        }
+
         // If the browser does not support the replaceState method for the
         // History Web API, the "code" parameter cannot be removed. As a
         // consequence, the page will (re)authorize on every load. The

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -201,6 +201,24 @@ declare namespace fhirclient {
         _clearState(): Promise<void>;
 
         /**
+         * Wrapper for `client.request` implementing the FHIR resource create operation
+         * @param {Object} resource A FHIR resource to be created
+         */
+        create(resource: object): Promise<RequestResult>
+
+        /**
+         * Wrapper for `client.request` implementing the FHIR resource update operation
+         * @param {Object} resource A FHIR resource to be updated
+         */
+        update(resource: object): Promise<RequestResult>
+
+        /**
+         * Wrapper for `client.request` implementing the FHIR resource delete operation
+         * @param {String} uri Relative URL of the FHIR resource to be deleted (format: `resourceType/id`)
+         */
+        delete(uri: string): Promise<RequestResult>
+
+        /**
          * Use this method to query the FHIR server
          * @param uri Either the full url, or a path that will be rooted at the FHIR baseUrl.
          * @param fhirOptions Additional options to control the behavior 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -214,7 +214,7 @@ declare namespace fhirclient {
 
         /**
          * Wrapper for `client.request` implementing the FHIR resource delete operation
-         * @param {String} uri Relative URL of the FHIR resource to be deleted (format: `resourceType/id`)
+         * @param {String} uri Relative URI of the FHIR resource to be deleted (format: `resourceType/id`)
          */
         delete(uri: string): Promise<RequestResult>
 


### PR DESCRIPTION
While testing the new JS client, I found that it fails in Firefox if the user refreshes the app. This was tricky to debug. The culprit is a nasty Firefox bug which manifests itself by overriding a URL set through `history.replaceState` after 3xx redirect with "Location" header (such as the one after auth with MitreID Connect). This results in the "code" and other URL parameters cleared by the client springing back after a user-initiated refresh. The old JS client was able to deal with this, because it detected a refresh of the app by inspecting the localStorage. The new client detects a refresh by inspecting the URL parameters and fails to detect the refresh resulting in failure.

The best workaround for the Firefox bug is to execute `location.hash = location.hash` before `history.replaceState`. This makes the bug go away, but may add a hash to the URL on some browsers as a side effect. In practice, this should not be a problem for most web apps, but just in case, I added an options parameter for conveniently disabling the workaround.

---

The old JS client used to support patient-context aware FHIR querying  via FHIR.js. This was useful functionality which is missing in the current client. I implemented a wrapper for the `client.request` method mapped to `client.patient.request` which provides very similar functionality.

---

I also implemented convenience wrappers for the FHIR create/update/delete operations.

---

Finally, this contains a fix for the fake token response workflow.