### PR TITLE
Workaround for a nasty Firefox issue

### DIFF
--- a/src/smart.js
+++ b/src/smart.js
@@ -310,9 +310,13 @@ async function completeAuth(env)
         throw new Error("No state found! Please (re)launch the app.");
     }
 
-    // If we have state, then check to see if we got a `code`. If we don't,
-    // then this is just a reload. Otherwise, we have to complete the code flow
-    if (code) {
+    // Assume the client has already completed a token exchange when
+    // there is no code or access token is found in state
+    const authorized = !code || state.tokenResponse.access_token;
+
+    // If we are authorized already, then this is just a reload.
+    // Otherwise, we have to complete the code flow
+    if (!authorized) {
         debug("Preparing to exchange the code for access token...");
         const requestOptions = await buildTokenRequest(code, state);
         debug("Token request options: %O", requestOptions);


### PR DESCRIPTION
While testing the new JS client, I found that it fails in Firefox if the user refreshes the app. This was tricky to debug. The culprit is a nasty Firefox bug which manifests itself by overriding a URL set through history.replaceState after 3xx redirect with "Location" header (such as the one after auth with MitreID Connect). This results in the "code" and other URL parameters cleared by the client springing back after a user-initiated refresh. The old JS client was able to deal with this, because it detected a refresh of the app by inspecting the localStorage. The new client detects a refresh by inspecting the URL parameters and fails to detect the refresh resulting in failure.