### PR TITLE
Returning response if status = 201

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -103,12 +103,14 @@ export function request<T = Response | fhirclient.JsonObject | string>(
     })
         .then(checkResponse)
         .then((res: Response) => {
-            const type = res.headers.get("Content-Type") + "";
-            if (type.match(/\bjson\b/i)) {
-                return responseToJSON(res);
-            }
-            if (type.match(/^text\//i)) {
-                return res.text();
+            if (res.status !== 201) {
+                const type = res.headers.get("Content-Type") + "";
+                if (type.match(/\bjson\b/i)) {
+                    return responseToJSON(res);
+                }
+                if (type.match(/^text\//i)) {
+                    return res.text();
+                }
             }
             return res;
         });


### PR DESCRIPTION
Hello,

This is an attempt to address #76 by checking whether the response status is "201" before attempting to parse it out as JSON or HTML/TEXT, allowing the full response to be retrieved. In the case of CREATE interaction, this would expose the "location" header as defined in the FHIR spec (https://www.hl7.org/fhir/http.html#create), subsequently allowing easy reference to the newly-created resource.

Thank you for your consideration.