### PR TITLE
Prioritize reading the fhirUser attribute in the id token

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -583,7 +583,7 @@ export default class Client
     {
         const idToken = this.getIdToken();
         if (idToken) {
-            return idToken.profile;
+            return idToken.fhirUser || idToken.profile;
         }
         return null;
     }


### PR DESCRIPTION
### Context
The latest SMART on FHIR spec deprecates the use of the `profile` claim in favor of the `fhirUser` claim. Refer to docs [here](http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#scopes-for-requesting-identity-data). 

This pull request prioritizes reading the fhirUser from the `fhirUser` attribute in the id token. For backward compatibility, if the `fhirUser` attribute does not exist, it reads the `profile` attribute.