### PR TITLE
Allow overriding the Authorization header

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -808,8 +808,8 @@ export default class Client
                 const authHeader = this.getAuthorizationHeader();
                 if (authHeader) {
                     requestOptions.headers = {
-                        ...requestOptions.headers,
-                        Authorization: authHeader
+                        Authorization: authHeader,
+                        ...requestOptions.headers
                     };
                 }
                 return requestOptions;

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -1013,6 +1013,27 @@ describe("FHIR.client", () => {
             });
         });
 
+        describe("allow overriding the authorization header", () => {
+            crossPlatformTest(async (env) => {
+                const client = new Client(env, {
+                    serverUrl: mockUrl,
+                    tokenResponse: {
+                        access_token: "abc",
+                    }
+                });
+
+                mockServer.mock({
+                    handler(req, res) {
+                        res.json(req.headers.authorization);
+                    }
+                });
+
+                const headers = {"Authorization": "Bearer xyz"};
+                const result = await client.request({url: "/", headers});
+                expect(result).to.equal(headers.Authorization);
+            });
+        });
+
         // ---------------------------------------------------------------------
 
         describe ("can fetch single resource", () => {


### PR DESCRIPTION
In our project we need a separate token for mutations. I expected to be able to override the `Authorization` header like this:

```ts
    const headers = {'Authorization': `Bearer ${state.token}`};

    return client.update(resource, {headers});
```

However, the `tokenResponse` takes presence.