### PR TITLE
Making client_id controllable vie URL

### DIFF
--- a/src/smart.ts
+++ b/src/smart.ts
@@ -238,7 +238,6 @@ export async function authorize(
     fhirServiceUrl = url.searchParams.get("fhirServiceUrl") || fhirServiceUrl;
     launch         = url.searchParams.get("launch")         || launch;
 
-    
     if (!clientId) {
         clientId = client_id || (url.searchParams.get("clientId") ?? undefined);
     }

--- a/src/smart.ts
+++ b/src/smart.ts
@@ -238,6 +238,11 @@ export async function authorize(
     fhirServiceUrl = url.searchParams.get("fhirServiceUrl") || fhirServiceUrl;
     launch         = url.searchParams.get("launch")         || launch;
 
+    // For these url param inline takes precedence over url parameter
+    if (!client_id) {
+        client_id = url.searchParams.get("client_id")  
+    }
+    
     if (!clientId) {
         clientId = client_id;
     }

--- a/src/smart.ts
+++ b/src/smart.ts
@@ -238,13 +238,9 @@ export async function authorize(
     fhirServiceUrl = url.searchParams.get("fhirServiceUrl") || fhirServiceUrl;
     launch         = url.searchParams.get("launch")         || launch;
 
-    // For these url param inline takes precedence over url parameter
-    if (!client_id) {
-        client_id = url.searchParams.get("client_id")  
-    }
     
     if (!clientId) {
-        clientId = client_id;
+        clientId = client_id || (url.searchParams.get("clientId") ?? undefined);
     }
 
     if (!redirectUri) {


### PR DESCRIPTION
While it may make sense to control the client_id via the URL, it is likely not wished in all cases. To avoid misusage, the one from the launch.html wins if existing