### PR TITLE
Add refreshTokenWithClientId option, to send client_id when using a refresh token

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1039,7 +1039,10 @@ export default class Client
         // requests in parallel which may result in multiple refresh calls.
         // To avoid that, we keep a reference to the current refresh task (if any).
         if (!this._refreshTask) {
-
+            let body = `grant_type=refresh_token&refresh_token=${encodeURIComponent(refreshToken)}`;
+            if (this.environment.options.refreshTokenWithClientId) {
+                body += `&client_id=${this.state.clientId}`;
+            }
             const refreshRequestOptions = {
                 credentials: this.environment.options.refreshTokenWithCredentials || "same-origin",
                 ...requestOptions,
@@ -1049,7 +1052,7 @@ export default class Client
                     ...(requestOptions.headers || {}),
                     "content-type": "application/x-www-form-urlencoded"
                 },
-                body: `grant_type=refresh_token&refresh_token=${encodeURIComponent(refreshToken)}`
+                body: body
             };
 
             // custom authorization header can be passed on manual calls

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -105,6 +105,15 @@ declare namespace fhirclient {
          */
         refreshTokenWithCredentials?: "omit" | "include" | "same-origin";
 
+        /**
+         * Some OAuth implementations require the client_id to be sent
+         * when using a refresh token.
+         * Setting `FHIR.oauth2.settings.refreshTokenWithClientId = true`
+         * enables this behaviour, sending the "client_id" parameter in
+         * the refresh request body.
+         */
+        refreshTokenWithClientId?: boolean;
+
         // storage?: Storage | ((options?: JsonObject) => Storage);
     }
 


### PR DESCRIPTION
Some OAuth providers (e.g. Keycloak) require that client_id is sent when using a refresh token.  
This patch adds the `refreshTokenWithClientId` option that may be used similarly to the `refreshTokenWithCredentials`.  
When `true`, the request body for the token refresh will also send a `client_id` parameter fetched from the state.  
I have locally tested this patch and it produces the desired behaviour, though I've not commit the packed dist bundle files yet.  

The `refreshTokenWithCredentials` option wouldn't be suitable when using a public client as no credentials are known.  

Evidence of Keycloak's behaviour may be found on the [discourse](https://keycloak.discourse.group/t/is-client-id-always-required-to-refresh-a-token/4378/3).  