### PR TITLE
Mark @types/hapi peer dependency as optional

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -31,6 +31,11 @@
     "@types/hapi": ">=18",
     "@types/node": ">=18"
   },
+  "peerDependenciesMeta": {
+    "@types/hapi": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
A relatively minor thing, but I don't want to add @types/hapi to my app just to satisfy yarn when these types are seemingly only used internally or when used as in the hapi-example.


![image](https://github.com/user-attachments/assets/95c8b0dc-7673-4489-ac4b-6724b6fd9aaf)
