### PR TITLE
Distinguish RFC 9207 iss from SMART launch iss on OAuth callbacks

### DIFF
--- a/src/smart.ts
+++ b/src/smart.ts
@@ -47,6 +47,7 @@ async function getSecurityExtensionsFromWellKnownJson(baseUrl = "/", requestOpti
             throw new Error("Invalid wellKnownJson");
         }
         return {
+            issuer              : meta.issuer,
             registrationUri     : meta.registration_endpoint  || "",
             authorizeUri        : meta.authorization_endpoint,
             tokenUri            : meta.token_endpoint,
@@ -126,6 +127,18 @@ export async function authorize(
 
     // Multiple config for EHR launches ---------------------------------------
     if (Array.isArray(params)) {
+
+        // If `code` is present this is an OAuth callback, not a launch.
+        // Any `iss` on the URL is the RFC 9207 authorization-server issuer,
+        // NOT the SMART FHIR server base URL — do not use it for config
+        // selection. In this case, call ready() instead.
+        if (url.searchParams.has("code")) {
+            throw new Error(
+                'authorize() called with multiple configurations during an ' +
+                'OAuth callback (URL contains "code"). Use init() or ' +
+                'ready() to complete the authorization flow.'
+            );
+        }
         const urlISS = url.searchParams.get("iss") || url.searchParams.get("fhirServiceUrl");
         if (!urlISS) {
             throw new Error(
@@ -184,9 +197,14 @@ export async function authorize(
 
     const storage = env.getStorage();
 
+    // If `code` is present this is an OAuth callback, not a launch.
+    // Any `iss` on the URL would be the RFC 9207 authorization-server issuer
+    // (not the SMART FHIR server base URL), so we must not read it here.
+    const isCallback = url.searchParams.has("code");
+
     // For these, a url param takes precedence over inline option
-    iss            = url.searchParams.get("iss")            || iss;
-    fhirServiceUrl = url.searchParams.get("fhirServiceUrl") || fhirServiceUrl;
+    iss            = (!isCallback && url.searchParams.get("iss"))            || iss;
+    fhirServiceUrl = (!isCallback && url.searchParams.get("fhirServiceUrl")) || fhirServiceUrl;
     launch         = url.searchParams.get("launch")         || launch;
     patientId      = url.searchParams.get("patientId")      || patientId;
     clientId       = url.searchParams.get("clientId")       || clientId;
@@ -525,6 +543,22 @@ export async function ready(env: fhirclient.Adapter, options: fhirclient.ReadyOp
 
     url.searchParams.delete("complete");
 
+    // RFC 9207: If the callback URL contains an `iss` parameter and we know
+    // the expected authorization server issuer from discovery, validate them.
+    // A mismatch indicates a mix-up attack or misconfiguration.
+    // This runs before URL cleanup so we can still read the `iss` param.
+    if (code && state) {
+        const callbackIss = params.get("iss");
+        if (callbackIss && state.issuer) {
+            assert(
+                callbackIss === state.issuer,
+                `RFC 9207 issuer mismatch: callback "iss" is "${callbackIss}" ` +
+                `but the expected issuer is "${state.issuer}"`
+            );
+            debug("RFC 9207 issuer validated successfully: %s", callbackIss);
+        }
+    }
+
     // Do we have to remove the `code` and `state` params from the URL?
     const hasState = params.has("state") || options.stateKey ? true : false;
 
@@ -535,6 +569,16 @@ export async function ready(env: fhirclient.Adapter, options: fhirclient.ReadyOp
         if (code) {
             params.delete("code");
             debug("Removed code parameter from the url.");
+
+            // In callback mode, `iss` (if present) is the RFC 9207
+            // authorization-server issuer — NOT the SMART FHIR server
+            // base URL. Remove it so it does not leak into any subsequent
+            // authorize() call on the same page (e.g. init() flows).
+            // Validation against discovery metadata happens above.
+            if (params.has("iss")) {
+                params.delete("iss");
+                debug("Removed iss parameter from the url (RFC 9207 issuer, not FHIR server URL).");
+            }
         }
 
         // If we have `fullSessionStorageSupport` it means we no longer

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -328,6 +328,12 @@ declare namespace fhirclient {
     interface OAuthSecurityExtensions {
 
         /**
+         * The authorization server's issuer identifier (RFC 8414 / RFC 9207).
+         * If known, used to validate the `iss` callback parameter.
+         */
+        issuer?: string;
+
+        /**
          * You could register new SMART client at this endpoint (if the server
          * supports dynamic client registration)
          */
@@ -360,6 +366,13 @@ declare namespace fhirclient {
          * at authorization time from request query params of from config options.
          */
         serverUrl: string;
+
+        /**
+         * The authorization server's issuer identifier (RFC 8414 / RFC 9207).
+         * Discovered from `.well-known/smart-configuration` during authorize.
+         * Used to validate the `iss` parameter on OAuth callbacks.
+         */
+        issuer?: string;
 
         /**
          * The client_id that you should have obtained while registering your
@@ -923,6 +936,12 @@ declare namespace fhirclient {
     type permissions = "permission-offline" | "permission-patient" | "permission-user";
 
     interface WellKnownSmartConfiguration {
+        /**
+         * The authorization server's issuer identifier (RFC 8414 / RFC 9207).
+         * Used to validate the `iss` parameter on OAuth callbacks.
+         */
+        issuer?: string;
+
         /**
          * URL to the OAuth2 authorization endpoint.
          */

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -301,6 +301,247 @@ describe("Browser tests", () => {
             expect(client.getUserType()).to.equal("Practitioner");
         });
 
+        // RFC 9207 iss collision tests -------------------------------------------
+
+        it ("callback with code and RFC 9207 iss does not treat iss as FHIR server URL", async () => {
+
+            const env = new BrowserEnv();
+            const Storage = env.getStorage();
+
+            // mock our oauth endpoints
+            mockServer.mock({
+                headers: { "content-type": "application/json" },
+                status: 200,
+                body: {
+                    authorization_endpoint: mockUrl,
+                    token_endpoint: mockUrl
+                }
+            });
+
+            // 1. authorize (launch mode) — iss is the FHIR server
+            await smart.authorize(env, {
+                iss: mockUrl,
+                launch: "123",
+                scope: "my_scope",
+                client_id: "my_client_id"
+            });
+
+            const redirect = env.getUrl();
+            const state = redirect.searchParams.get("state");
+            expect(await Storage.get(state)).to.exist();
+
+            // Verify that the stored serverUrl is the FHIR server (mockUrl)
+            const storedState = await Storage.get(state);
+            expect(storedState.serverUrl).to.equal(mockUrl);
+
+            // mock access token response
+            mockServer.mock({
+                headers: { "content-type": "application/json" },
+                status: 200,
+                body: {
+                    "patient": "test-patient-1",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                    "access_token": "test-access-token",
+                    state
+                }
+            });
+
+            // 2. Simulate callback with code, state, AND a RFC 9207 iss
+            //    that is an auth server URL (different from the FHIR server)
+            env.redirect(
+                "http://localhost/?code=abc&state=" + state +
+                "&iss=" + encodeURIComponent("https://auth.example.com/realms/test")
+            );
+            const client = await smart.ready(env);
+
+            // The client should use the stored FHIR server URL, NOT the
+            // RFC 9207 iss from the callback
+            expect(client.state.serverUrl).to.equal(mockUrl);
+
+            // iss should have been stripped from the browser URL
+            expect(window.history._location).to.not.contain("iss=");
+        });
+
+        it ("callback with code and no iss still works", async () => {
+
+            const env = new BrowserEnv();
+            const Storage = env.getStorage();
+
+            mockServer.mock({
+                headers: { "content-type": "application/json" },
+                status: 200,
+                body: {
+                    authorization_endpoint: mockUrl,
+                    token_endpoint: mockUrl
+                }
+            });
+
+            await smart.authorize(env, {
+                iss: mockUrl,
+                launch: "123",
+                scope: "my_scope",
+                client_id: "my_client_id"
+            });
+
+            const redirect = env.getUrl();
+            const state = redirect.searchParams.get("state");
+
+            mockServer.mock({
+                headers: { "content-type": "application/json" },
+                status: 200,
+                body: {
+                    "patient": "test-patient-1",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                    "access_token": "test-access-token",
+                    state
+                }
+            });
+
+            // Callback with code and state but NO iss
+            env.redirect("http://localhost/?code=abc&state=" + state);
+            const client = await smart.ready(env);
+
+            expect(client.state.serverUrl).to.equal(mockUrl);
+        });
+
+        it ("launch URL with iss and no code reads iss as FHIR server URL", async () => {
+
+            const env = new BrowserEnv();
+
+            // Point the browser at a launch URL with iss
+            env.redirect("http://localhost/launch?iss=" + encodeURIComponent(mockUrl) + "&launch=xyz");
+
+            mockServer.mock({
+                headers: { "content-type": "application/json" },
+                status: 200,
+                body: {
+                    authorization_endpoint: mockUrl + "/authorize",
+                    token_endpoint: mockUrl + "/token"
+                }
+            });
+
+            const redirectUrl = await smart.authorize(env, {
+                client_id: "my_client_id",
+                scope: "my_scope",
+                noRedirect: true
+            });
+
+            // The redirect should have aud=<FHIR server URL>
+            const redirectParsed = new URL(redirectUrl as string);
+            // The state was stored; check that serverUrl came from iss
+            const stateKey = redirectParsed.searchParams.get("state");
+            const Storage = env.getStorage();
+            const storedState = await Storage.get(stateKey);
+            expect(storedState.serverUrl).to.equal(mockUrl);
+        });
+
+        it ("authorize with multi-config ignores iss when code is present", async () => {
+
+            const env = new BrowserEnv();
+
+            // Simulate a callback URL that has code + RFC 9207 iss
+            env.redirect(
+                "http://localhost/?code=abc&state=test123" +
+                "&iss=" + encodeURIComponent("https://auth.example.com/realms/test")
+            );
+
+            // Multi-config authorize should fail because code is present
+            // (this is a callback, not a launch)
+            await expect(smart.authorize(env, [
+                { issMatch: "https://auth.example.com/realms/test" },
+                { issMatch: mockUrl }
+            ])).to.reject(/authorize\(\) called with multiple configurations during an OAuth callback.*Use init\(\) or ready\(\)/);
+        });
+
+        it ("RFC 9207 issuer validation passes when iss matches discovered issuer", async () => {
+
+            const env = new BrowserEnv();
+            const Storage = env.getStorage();
+            const authIssuer = "https://auth.example.com/realms/test";
+
+            // Mock well-known with an issuer field
+            mockServer.mock({
+                headers: { "content-type": "application/json" },
+                status: 200,
+                body: {
+                    issuer: authIssuer,
+                    authorization_endpoint: mockUrl + "/authorize",
+                    token_endpoint: mockUrl + "/token"
+                }
+            });
+
+            await smart.authorize(env, {
+                iss: mockUrl,
+                launch: "123",
+                scope: "my_scope",
+                client_id: "my_client_id"
+            });
+
+            const redirect = env.getUrl();
+            const state = redirect.searchParams.get("state");
+
+            // Verify issuer was stored
+            const storedState = await Storage.get(state);
+            expect(storedState.issuer).to.equal(authIssuer);
+
+            mockServer.mock({
+                headers: { "content-type": "application/json" },
+                status: 200,
+                body: {
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                    "access_token": "test-access-token",
+                    state
+                }
+            });
+
+            // Callback with matching issuer — should succeed
+            env.redirect(
+                "http://localhost/?code=abc&state=" + state +
+                "&iss=" + encodeURIComponent(authIssuer)
+            );
+            const client = await smart.ready(env);
+            expect(client.state.serverUrl).to.equal(mockUrl);
+        });
+
+        it ("RFC 9207 issuer validation fails on mismatch", async () => {
+
+            const env = new BrowserEnv();
+            const Storage = env.getStorage();
+            const authIssuer = "https://auth.example.com/realms/test";
+
+            mockServer.mock({
+                headers: { "content-type": "application/json" },
+                status: 200,
+                body: {
+                    issuer: authIssuer,
+                    authorization_endpoint: mockUrl + "/authorize",
+                    token_endpoint: mockUrl + "/token"
+                }
+            });
+
+            await smart.authorize(env, {
+                iss: mockUrl,
+                launch: "123",
+                scope: "my_scope",
+                client_id: "my_client_id"
+            });
+
+            const redirect = env.getUrl();
+            const state = redirect.searchParams.get("state");
+
+            // Callback with WRONG issuer — should fail
+            env.redirect(
+                "http://localhost/?code=abc&state=" + state +
+                "&iss=" + encodeURIComponent("https://evil.example.com/realms/fake")
+            );
+            await expect(smart.ready(env)).to.reject(/RFC 9207 issuer mismatch/);
+        });
+
+        // -----------------------------------------------------------------
+
         it ("refresh an authorized page", async () => {
 
             const env = new BrowserEnv();
@@ -697,6 +938,7 @@ describe("Browser tests", () => {
 
                 const result = await smart.getSecurityExtensions(mockUrl);
                 expect(result).to.equal({
+                    issuer              : undefined,
                     registrationUri     : "https://my-register-uri",
                     authorizeUri        : "https://my-authorize-uri",
                     tokenUri            : "https://my-token-uri",
@@ -718,6 +960,7 @@ describe("Browser tests", () => {
 
               const result = await smart.getSecurityExtensions(mockUrl);
               expect(result).to.equal({
+                  issuer              : undefined,
                   registrationUri     : "https://my-register-uri",
                   authorizeUri        : "https://my-authorize-uri",
                   tokenUri            : "https://my-token-uri",
@@ -1480,6 +1723,61 @@ describe("Browser tests", () => {
                 expect(client.getEncounterId()).to.equal("e3ec2d15-4c27-4607-a45c-2f84962b0700");
                 expect(client.getUserId()).to.equal("smart-Practitioner-71482713");
                 expect(client.getUserType()).to.equal("Practitioner");
+            });
+
+            it ("init() handles RFC 9207 iss on callback without treating it as FHIR server URL", async () => {
+                const authIssuer = "https://auth.example.com/realms/test";
+
+                mockServer.mock({
+                    headers: { "content-type": "application/json" },
+                    status: 200,
+                    body: {
+                        issuer: authIssuer,
+                        authorization_endpoint: mockUrl,
+                        token_endpoint: mockUrl
+                    }
+                });
+
+                mockServer.mock({
+                    headers: { "content-type": "application/json" },
+                    status: 200,
+                    body: {
+                        "patient": "test-patient-1",
+                        "token_type": "bearer",
+                        "expires_in": 3600,
+                        "access_token": "test-access-token"
+                    }
+                });
+
+                const env = new BrowserEnv();
+
+                const client = await new Promise<any>((resolve, reject) => {
+
+                    env.once("redirect", async () => {
+                        // Simulate callback with code, state, AND RFC 9207 iss
+                        const stateKey = env.getUrl().searchParams.get("state");
+                        env.redirect(
+                            "http://localhost/?code=123&state=" + stateKey +
+                            "&iss=" + encodeURIComponent(authIssuer)
+                        );
+                        smart.init(env, {
+                            client_id : "my_web_app",
+                            scope     : "launch/patient",
+                            iss       : mockUrl
+                        }).then(resolve).catch(reject);
+                    });
+
+                    smart.init(env, {
+                        client_id : "my_web_app",
+                        scope     : "launch/patient",
+                        iss       : mockUrl
+                    }).catch(reject);
+                });
+
+                // Should use the stored FHIR server URL, not the RFC 9207 iss
+                expect(client.state.serverUrl).to.equal(mockUrl);
+                // iss should have been stripped from the browser URL
+                expect(window.history._location).to.not.contain("iss=");
             });
         });
     });


### PR DESCRIPTION
## Summary

- The `iss` query parameter has two conflicting meanings. SMART App Launch uses it for the FHIR server base URL on launch, while RFC 9207 uses it for the authorization server issuer on OAuth callbacks. Auth servers like Keycloak include RFC 9207 `iss` by default, which breaks apps when the library mistakes it for the FHIR server URL.
- As a solution, this change makes callback mode ignore URL `iss` for FHIR server selection (use stored state instead), and validate it against the discovered issuer when available (implementing RFC 9207), and strips it from the browser URL.
- Also added `issuer` field to `WellKnownSmartConfiguration`, `OAuthSecurityExtensions`, and `ClientState` types to support RFC 9207 validation.

## Behavioral changes

| Scenario | Before | After |
|----------|--------|-------|
| Callback URL has `code` + RFC 9207 `iss` | `iss` mistakenly used as FHIR server URL | `iss` ignored for FHIR server; validated against discovery issuer if known |
| Callback URL has `code`, no `iss` | Works | No change |
| Launch URL has `iss`, no `code` | `iss` read as FHIR server URL | No change |
| Multi-config `authorize()` called on callback URL | Confusing error or wrong config match | Clear error directing to `init()`/`ready()` |
| Server publishes `issuer` in `.well-known`, callback `iss` mismatches | Silently accepted | Throws `RFC 9207 issuer mismatch` error |

## Limitations

- RFC 9207 issuer validation only works when the server publishes `issuer` in `.well-known/smart-configuration`. Conformance-only servers (no well-known) skip validation gracefully since the expected issuer is unknown.
- The `iss` URL cleanup in `ready()` is gated behind `replaceBrowserHistory` (the default). Apps with `replaceBrowserHistory: false` retain `iss` in the URL bar, consistent with existing `code`/`state` behavior under that setting.

## Tests

- Callback with `code` + RFC 9207 `iss` uses stored FHIR server URL, not callback `iss`
- Callback with `code` and no `iss` still works (regression)
- Launch URL with `iss` and no `code` reads `iss` as FHIR server URL (regression)
- Multi-config `authorize()` on callback throws clear error
- RFC 9207 issuer validation passes when `iss` matches discovered issuer
- RFC 9207 issuer validation fails on mismatch with clear error
- `init()` end-to-end flow handles RFC 9207 `iss` on callback correctly
- All 427 tests pass (7 new, 420 existing unchanged)

## References

This relates to this PR on the SMART on FHIR specification https://github.com/HL7/smart-app-launch/pull/419 ([Jira change request](https://jira.hl7.org/browse/FHIR-56141)) and [this Zulip thread](https://chat.fhir.org/#narrow/channel/179170-smart/topic/iss.20parameter.20collision.20with.20RFC.209207/with/580506704).